### PR TITLE
Potential issue in include/igl/readOFF.cpp: Unchecked return from initialization function

### DIFF
--- a/include/igl/readOFF.cpp
+++ b/include/igl/readOFF.cpp
@@ -59,7 +59,7 @@ IGL_INLINE bool igl::readOFF(
   bool has_vertexColors = string(header).compare(0,COFF.length(),COFF)==0;
   // Second line is #vertices #faces #edges
   int number_of_vertices;
-  int number_of_faces;
+  int number_of_faces = 0;
   int number_of_edges;
   char tic_tac_toe;
   char line[1000];
@@ -134,7 +134,7 @@ IGL_INLINE bool igl::readOFF(
       face.resize(valence);
       for(int j = 0;j<valence;j++)
       {
-        int index;
+        int index = 0;
         if(j<valence-1)
         {
           fscanf(off_file,"%d",&index);


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

**2 instances** of this defect were found in the following locations:

---
**Instance 1**
File : `include/igl/readOFF.cpp` 
Enclosing Function : `$readOFF@NH@igl`
Function : `sscanf` 
https://github.com/sagpant/libigl/blob/48a7e8cd02d3fb545ce4367d4567c62908437ab0/include/igl/readOFF.cpp#L72
**Issue in**: _number_of_faces_

**Code extract**:

```cpp
    fgets(line,1000,off_file);
    still_comments = (line[0] == '#' || line[0] == '\n');
  }
  sscanf(line,"%d %d %d",&number_of_vertices,&number_of_faces,&number_of_edges); <------ HERE
  V.resize(number_of_vertices);
  if (has_normals)
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.

---
**Instance 2**
File : `include/igl/readOFF.cpp` 
Enclosing Function : `$readOFF@NH@igl`
Function : `fscanf` 
https://github.com/sagpant/libigl/blob/48a7e8cd02d3fb545ce4367d4567c62908437ab0/include/igl/readOFF.cpp#L142
**Issue in**: _index_

**Code extract**:

```cpp
        {
          fscanf(off_file,"%d",&index);
        }else{
          fscanf(off_file,"%d%*[^\n]",&index); <------ HERE
        }

```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
